### PR TITLE
Switch memoization engine to chimera

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DataKinds #-}
+
+module Main where
+
+import NumberWall
+import Test.Tasty.Bench
+
+showPagoda n =
+  showSection show (0, n * 2) (0, n) $ numberWall ((pagoda :: Int -> Mod 2) . (+ n))
+
+main = defaultMain
+  [ bench "showPagoda" $ nf showPagoda 256
+  ]

--- a/number-wall.cabal
+++ b/number-wall.cabal
@@ -80,3 +80,15 @@ test-suite test
   build-depends:
     base,
     number-wall
+
+benchmark bench
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench
+  default-language: Haskell2010
+  ghc-options:      -W
+  main-is:          Main.hs
+
+  build-depends:
+    base,
+    number-wall,
+    tasty-bench

--- a/number-wall.cabal
+++ b/number-wall.cabal
@@ -65,7 +65,7 @@ library
 
   build-depends:
     base >= 4.14.1.0 && < 5,
-    memoize >= 0.2.0 && < 1.2,
+    chimera >= 0.3.2.0 && < 0.4,
     mod >= 0.1.1.0 && < 0.2,
     semirings >= 0.5.2 && < 0.8,
     JuicyPixels >= 3.3 && < 3.4

--- a/src/NumberWall.hs
+++ b/src/NumberWall.hs
@@ -16,6 +16,7 @@ saveImage "pagoda.png" color (0, 256) (0, 128) wall
 
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module NumberWall
   ( NumberWall, Col, Row, numberWall, pagoda, rueppel, ternary, saveImage, showSection, printSection
   , module Data.Mod.Word
@@ -23,7 +24,8 @@ module NumberWall
 
 import Prelude hiding (negate, (*), (+), (-), (^), quot)
 
-import Data.Function.Memoize (memoFix2)
+import Data.Chimera (VChimera, index, tabulateFix')
+import Data.Chimera.ContinuousMapping (fromZCurve, toZCurve, wordToInt, intToWord)
 import Data.Semiring (Semiring, Ring, zero, one, negate, (*), (+), (-), (^))
 import Data.Euclidean (Euclidean, quot)
 
@@ -47,6 +49,16 @@ type Row = Int
 
 sign :: Ring a => Int -> a
 sign x = if even x then one else negate one
+
+memoFix2 :: forall a. ((Int -> Int -> a) -> (Int -> Int -> a)) -> (Int -> Int -> a)
+memoFix2 f = uncast $ index $ (tabulateFix' (\g -> cast (f (uncast g))) :: VChimera a)
+  where
+    cast :: (Int -> Int -> a) -> (Word -> a)
+    cast f = \n -> let (x, y) = fromZCurve n in
+     f (wordToInt x) (wordToInt y)
+
+    uncast :: (Word -> a) -> (Int -> Int -> a)
+    uncast g = \x y -> g (toZCurve (intToWord x) (intToWord y))
 
 {-|
 Generate the number wall for a sequence.


### PR DESCRIPTION
For dense memoization `chimera` is expected to be faster than `memoize`, and indeed there is 2x speed up overall:
```
$ compareBenches main~1 main --stdev=2
All
  showPagoda: OK
    2.838 s ± 9.1 ms
All
  showPagoda: OK
    1.324 s ±  32 ms, 53% less than baseline
```